### PR TITLE
Uupdate runtime image to bullseye for glibc6.29

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY Cargo.lock /usr/src/traefik-pages/Cargo.lock
 RUN cargo build --release
 
 # Runtime
-FROM debian:bullseye-slim
+FROM debian:slim
 
 COPY --from=builder /usr/src/traefik-pages/target/release/traefik-pages /usr/local/bin/traefik-pages
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY Cargo.lock /usr/src/traefik-pages/Cargo.lock
 RUN cargo build --release
 
 # Runtime
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 COPY --from=builder /usr/src/traefik-pages/target/release/traefik-pages /usr/local/bin/traefik-pages
 


### PR DESCRIPTION
debian:buster-slim has an outdated version of glibc and will not run the traefik-pages binary. bullseye-slim has the correct glibc version